### PR TITLE
fix(mobile): blur category select after selection to fix focus issue

### DIFF
--- a/src/components/ui/Dialog.tsx
+++ b/src/components/ui/Dialog.tsx
@@ -107,7 +107,7 @@ export function Dialog({ isOpen, onClose, title, children }: DialogProps) {
             </button>
           </div>
         )}
-        <div className="p-4 pb-8">{children}</div>
+        <div className="p-4 pb-8 touch-action-manipulation">{children}</div>
       </div>
       {/* Desktop modal */}
       <div

--- a/src/features/categories/CategorySelect.tsx
+++ b/src/features/categories/CategorySelect.tsx
@@ -57,6 +57,7 @@ export function CategorySelect({ value, onChange, error }: CategorySelectProps) 
                 return
               }
               onChange(e.target.value)
+              e.target.blur()
             }}
             className={`
               w-full py-2 pr-3 rounded-lg border appearance-none


### PR DESCRIPTION
On mobile browsers, the native select element retains focus after the picker closes, preventing other inputs from receiving taps. Adding explicit blur() call releases focus and allows normal input interaction.

Also added touch-action-manipulation to Dialog content for improved touch handling.