### PR TITLE
Block future month navigation in calendar and date picker

### DIFF
--- a/src/components/ui/DateRangePicker.test.tsx
+++ b/src/components/ui/DateRangePicker.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DateRangePicker } from '@/components/ui/DateRangePicker'
+
+describe('DateRangePicker', () => {
+  const defaultProps = {
+    startDate: '2024-01-01',
+    endDate: '2024-01-15',
+    onRangeChange: vi.fn(),
+  }
+
+  describe('next button visibility', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2024, 0, 15)) // January 15, 2024
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('hides next button when viewing current month', () => {
+      render(<DateRangePicker {...defaultProps} />)
+
+      const nextButton = screen.queryByRole('button', { name: 'Next month' })
+      expect(nextButton).not.toBeInTheDocument()
+    })
+
+    it('shows next button when viewing past month', () => {
+      // Start date in December 2023 will set initial view to December 2023
+      render(
+        <DateRangePicker
+          {...defaultProps}
+          startDate="2023-12-01"
+          endDate="2023-12-15"
+        />
+      )
+
+      const nextButton = screen.getByRole('button', { name: 'Next month' })
+      expect(nextButton).toBeInTheDocument()
+    })
+
+    it('maintains layout spacing with placeholder when next button is hidden', () => {
+      const { container } = render(<DateRangePicker {...defaultProps} />)
+
+      const placeholder = container.querySelector('div.w-8.h-8[aria-hidden="true"]')
+      expect(placeholder).toBeInTheDocument()
+    })
+
+    it('hides next button after navigating to current month', () => {
+      render(
+        <DateRangePicker
+          {...defaultProps}
+          startDate="2023-12-01"
+          endDate="2023-12-15"
+        />
+      )
+
+      // Initially viewing December 2023, next button should be visible
+      let nextButton = screen.getByRole('button', { name: 'Next month' })
+      expect(nextButton).toBeInTheDocument()
+
+      // Navigate to January 2024 (current month)
+      fireEvent.click(nextButton)
+
+      // Next button should now be hidden
+      nextButton = screen.queryByRole('button', { name: 'Next month' }) as HTMLButtonElement
+      expect(nextButton).not.toBeInTheDocument()
+    })
+  })
+
+  describe('previous button', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2024, 0, 15))
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('always renders previous button', () => {
+      render(<DateRangePicker {...defaultProps} />)
+
+      const prevButton = screen.getByRole('button', { name: 'Previous month' })
+      expect(prevButton).toBeInTheDocument()
+    })
+
+    it('shows next button after navigating to previous month', () => {
+      render(<DateRangePicker {...defaultProps} />)
+
+      // Initially viewing January 2024 (current month), next button should be hidden
+      expect(screen.queryByRole('button', { name: 'Next month' })).not.toBeInTheDocument()
+
+      // Navigate to December 2023
+      const prevButton = screen.getByRole('button', { name: 'Previous month' })
+      fireEvent.click(prevButton)
+
+      // Next button should now be visible
+      expect(screen.getByRole('button', { name: 'Next month' })).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/ui/DateRangePicker.tsx
+++ b/src/components/ui/DateRangePicker.tsx
@@ -10,7 +10,7 @@ import {
 } from 'date-fns'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/Button'
-import { formatDateToISO, parseDateFromISO, getCalendarGrid } from '@/lib/dates'
+import { formatDateToISO, parseDateFromISO, getCalendarGrid, isCurrentOrFutureMonth } from '@/lib/dates'
 
 interface DateRangePickerProps {
   startDate: string
@@ -31,6 +31,10 @@ export function DateRangePicker({
   const start = parseDateFromISO(startDate)
   const end = parseDateFromISO(endDate)
   const max = maxDate ? parseDateFromISO(maxDate) : null
+
+  const viewYear = viewDate.getFullYear()
+  const viewMonth = viewDate.getMonth() + 1
+  const isViewingCurrentOrFutureMonth = isCurrentOrFutureMonth(viewYear, viewMonth)
 
   const handleDateClick = useCallback(
     (date: Date) => {
@@ -78,14 +82,18 @@ export function DateRangePicker({
         <span className="font-semibold text-[var(--color-text-primary)]">
           {format(viewDate, 'MMMM yyyy')}
         </span>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => setViewDate(addMonths(viewDate, 1))}
-          aria-label="Next month"
-        >
-          <ChevronRight className="w-5 h-5" />
-        </Button>
+        {isViewingCurrentOrFutureMonth ? (
+          <div className="w-8 h-8" aria-hidden="true" />
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setViewDate(addMonths(viewDate, 1))}
+            aria-label="Next month"
+          >
+            <ChevronRight className="w-5 h-5" />
+          </Button>
+        )}
       </div>
 
       <div className="mb-2 text-xs text-[var(--color-text-secondary)] text-center">

--- a/src/features/calendar/CalendarPage.tsx
+++ b/src/features/calendar/CalendarPage.tsx
@@ -53,14 +53,14 @@ export function CalendarPage() {
       if (Math.abs(diff) > 50) {
         if (diff > 0) {
           goToPreviousMonth()
-        } else {
+        } else if (!isCurrentMonth) {
           goToNextMonth()
         }
       }
 
       touchStartX.current = null
     },
-    [goToPreviousMonth, goToNextMonth]
+    [goToPreviousMonth, goToNextMonth, isCurrentMonth]
   )
 
   // Reset to current month on mount

--- a/src/features/calendar/MonthNavigator.test.tsx
+++ b/src/features/calendar/MonthNavigator.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MonthNavigator } from '@/features/calendar/MonthNavigator'
+
+describe('MonthNavigator', () => {
+  const defaultProps = {
+    monthLabel: 'January 2024',
+    onPrevious: vi.fn(),
+    onNext: vi.fn(),
+    onToday: vi.fn(),
+  }
+
+  describe('next button visibility', () => {
+    it('renders next button when not on current month', () => {
+      render(<MonthNavigator {...defaultProps} isCurrentMonth={false} />)
+
+      const nextButton = screen.getByRole('button', { name: 'Next month' })
+      expect(nextButton).toBeInTheDocument()
+    })
+
+    it('hides next button when on current month', () => {
+      render(<MonthNavigator {...defaultProps} isCurrentMonth={true} />)
+
+      const nextButton = screen.queryByRole('button', { name: 'Next month' })
+      expect(nextButton).not.toBeInTheDocument()
+    })
+
+    it('maintains layout spacing with placeholder when next button is hidden', () => {
+      const { container } = render(<MonthNavigator {...defaultProps} isCurrentMonth={true} />)
+
+      const placeholder = container.querySelector('div.w-8.h-8[aria-hidden="true"]')
+      expect(placeholder).toBeInTheDocument()
+    })
+  })
+
+  describe('previous button', () => {
+    it('always renders previous button', () => {
+      render(<MonthNavigator {...defaultProps} isCurrentMonth={true} />)
+
+      const prevButton = screen.getByRole('button', { name: 'Previous month' })
+      expect(prevButton).toBeInTheDocument()
+    })
+  })
+
+  describe('today button', () => {
+    it('shows today button when not on current month', () => {
+      render(<MonthNavigator {...defaultProps} isCurrentMonth={false} />)
+
+      const todayButton = screen.getByRole('button', { name: 'Go to today' })
+      expect(todayButton).toBeInTheDocument()
+    })
+
+    it('hides today button when on current month', () => {
+      render(<MonthNavigator {...defaultProps} isCurrentMonth={true} />)
+
+      const todayButton = screen.queryByRole('button', { name: 'Go to today' })
+      expect(todayButton).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/features/calendar/MonthNavigator.tsx
+++ b/src/features/calendar/MonthNavigator.tsx
@@ -36,14 +36,18 @@ export function MonthNavigator({ monthLabel, onPrevious, onNext, onToday, isCurr
           </Button>
         )}
       </div>
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={onNext}
-        aria-label="Next month"
-      >
-        <ChevronRight className="w-5 h-5" />
-      </Button>
+      {isCurrentMonth ? (
+        <div className="w-8 h-8" aria-hidden="true" />
+      ) : (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onNext}
+          aria-label="Next month"
+        >
+          <ChevronRight className="w-5 h-5" />
+        </Button>
+      )}
     </div>
   )
 }

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -7,6 +7,7 @@ import {
   getYearRange,
   isToday,
   isFutureDate,
+  isCurrentOrFutureMonth,
   getTodayISO,
 } from '@/lib/dates'
 
@@ -138,5 +139,41 @@ describe('getTodayISO', () => {
 
   it('returns today in ISO format', () => {
     expect(getTodayISO()).toBe('2024-01-15')
+  })
+})
+
+describe('isCurrentOrFutureMonth', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 0, 15)) // January 15, 2024
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns true for current month', () => {
+    expect(isCurrentOrFutureMonth(2024, 1)).toBe(true)
+  })
+
+  it('returns true for future months in same year', () => {
+    expect(isCurrentOrFutureMonth(2024, 2)).toBe(true)
+    expect(isCurrentOrFutureMonth(2024, 12)).toBe(true)
+  })
+
+  it('returns true for future years', () => {
+    expect(isCurrentOrFutureMonth(2025, 1)).toBe(true)
+    expect(isCurrentOrFutureMonth(2025, 6)).toBe(true)
+  })
+
+  it('returns false for past months in same year', () => {
+    vi.setSystemTime(new Date(2024, 5, 15)) // June 15, 2024
+    expect(isCurrentOrFutureMonth(2024, 1)).toBe(false)
+    expect(isCurrentOrFutureMonth(2024, 5)).toBe(false)
+  })
+
+  it('returns false for past years', () => {
+    expect(isCurrentOrFutureMonth(2023, 1)).toBe(false)
+    expect(isCurrentOrFutureMonth(2023, 12)).toBe(false)
   })
 })

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -79,6 +79,19 @@ export function isFutureDate(dateStr: string): boolean {
 }
 
 /**
+ * Check if a given year and month represent the current month or a future month
+ */
+export function isCurrentOrFutureMonth(year: number, month: number): boolean {
+  const now = new Date()
+  const currentYear = now.getFullYear()
+  const currentMonth = now.getMonth() + 1 // Convert to 1-indexed
+
+  if (year > currentYear) return true
+  if (year === currentYear && month >= currentMonth) return true
+  return false
+}
+
+/**
  * Get current date as ISO string
  */
 export function getTodayISO(): string {


### PR DESCRIPTION
Hide the next arrow button when viewing the current month to prevent navigation to future months. Uses a placeholder div to maintain layout spacing. Also blocks forward swipe gestures on the calendar page.