### PR TITLE
fix(pwa): add prompt-based update flow for reliable iOS updates

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useState, useCallback } from 'react'
 import { BottomNav } from '@/components/layout/BottomNav'
 import { ExpenseFormModal } from '@/features/expenses/ExpenseFormModal'
+import { UpdatePrompt } from '@/components/pwa/UpdatePrompt'
 import { useSettings } from '@/hooks/useSettings'
 import { getTodayISO, isFutureDate } from '@/lib/dates'
 import { CalendarContext } from '@/components/layout/CalendarContext'
@@ -77,6 +78,7 @@ export function AppLayout({ children }: AppLayoutProps) {
         <main className="max-w-lg mx-auto">
           {children}
         </main>
+        <UpdatePrompt />
         <BottomNav onAddExpense={handleAddExpense} />
         <ExpenseFormModal
           isOpen={showExpenseForm}

--- a/src/components/pwa/UpdatePrompt.tsx
+++ b/src/components/pwa/UpdatePrompt.tsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+import { X, RefreshCw } from 'lucide-react'
+import { usePWAUpdate } from '@/hooks/usePWAUpdate'
+
+export function UpdatePrompt() {
+  const { needRefresh, applyUpdate } = usePWAUpdate()
+  const [dismissed, setDismissed] = useState(false)
+
+  if (!needRefresh || dismissed) {
+    return null
+  }
+
+  return (
+    <div className="fixed bottom-20 left-0 right-0 z-50 px-4">
+      <div className="max-w-lg mx-auto bg-primary-500 text-white rounded-lg shadow-lg p-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <RefreshCw className="w-5 h-5 flex-shrink-0" />
+          <span className="text-sm font-medium truncate">
+            A new version is available
+          </span>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <button
+            onClick={applyUpdate}
+            className="px-3 py-1.5 bg-white text-primary-600 text-sm font-medium rounded-md hover:bg-primary-50 transition-colors"
+          >
+            Reload
+          </button>
+          <button
+            onClick={() => setDismissed(true)}
+            className="p-1 hover:bg-primary-600 rounded transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/usePWAUpdate.ts
+++ b/src/hooks/usePWAUpdate.ts
@@ -1,0 +1,28 @@
+import { useRegisterSW } from 'virtual:pwa-register/react'
+
+const UPDATE_CHECK_INTERVAL = 60 * 60 * 1000 // 1 hour
+
+export function usePWAUpdate() {
+  const {
+    needRefresh: [needRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (registration) {
+        // Check for updates periodically
+        setInterval(() => {
+          registration.update()
+        }, UPDATE_CHECK_INTERVAL)
+      }
+    },
+  })
+
+  const applyUpdate = () => {
+    updateServiceWorker(true)
+  }
+
+  return {
+    needRefresh,
+    applyUpdate,
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
-      registerType: 'autoUpdate',
+      registerType: 'prompt',
+      workbox: {
+        skipWaiting: true,
+        clientsClaim: true,
+      },
       includeAssets: ['favicon.svg', 'apple-touch-icon.svg'],
       manifest: {
         name: 'Pocket Ledger',


### PR DESCRIPTION
Switch from silent auto-updates to a prompt-based flow that shows a banner when a new version is available. This ensures iOS Safari properly activates new service workers when the app is launched from home screen.