### PR TITLE
refactor(categories): use key prop pattern instead of useEffect for form state

### DIFF
--- a/src/features/categories/CategoriesPage.tsx
+++ b/src/features/categories/CategoriesPage.tsx
@@ -55,6 +55,7 @@ export function CategoriesPage() {
       </div>
 
       <CategoryFormModal
+        key={editingCategory?.id ?? (isCreating ? 'create' : 'closed')}
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         category={editingCategory}

--- a/src/features/categories/CategoryFormModal.tsx
+++ b/src/features/categories/CategoryFormModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { Dialog } from '@/components/ui/Dialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { CategoryForm } from '@/features/categories/CategoryForm'
@@ -23,8 +23,8 @@ export function CategoryFormModal({
   onClose,
   category,
 }: CategoryFormModalProps) {
-  const [name, setName] = useState('')
-  const [color, setColor] = useState<string>(PRESET_COLORS[0])
+  const [name, setName] = useState(category?.name ?? '')
+  const [color, setColor] = useState<string>(category?.color ?? PRESET_COLORS[0])
 
   const createCategory = useCreateCategory()
   const updateCategory = useUpdateCategory()
@@ -39,18 +39,6 @@ export function CategoryFormModal({
   })
 
   const isEditing = !!category
-
-  useEffect(() => {
-    if (isOpen) {
-      if (category) {
-        setName(category.name)
-        setColor(category.color)
-      } else {
-        setName('')
-        setColor(PRESET_COLORS[0])
-      }
-    }
-  }, [isOpen, category])
 
   const handleSave = async () => {
     if (!name.trim()) return

--- a/src/features/categories/CategorySelect.tsx
+++ b/src/features/categories/CategorySelect.tsx
@@ -106,6 +106,7 @@ export function CategorySelect({ value, onChange, error }: CategorySelectProps) 
         onCreate={handleCreate}
       />
       <CategoryFormModal
+        key={editingCategory?.id ?? (isCreating ? 'create' : 'closed')}
         isOpen={isCreating || editingCategory !== null}
         onClose={handleCloseForm}
         category={editingCategory}


### PR DESCRIPTION
Replace setState calls inside useEffect with React's key prop pattern to reset CategoryFormModal state. This eliminates cascading renders and follows React's officially recommended approach for resetting state when props change.