### PR TITLE
refactor(forms): migrate to react-hook-form with Zod validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "pocket-ledger",
       "version": "0.0.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-visually-hidden": "^1.2.4",
         "@tanstack/react-query": "^5.62.0",
@@ -17,8 +18,10 @@
         "react": "^19.2.3",
         "react-currency-input-field": "^4.0.3",
         "react-dom": "^19.2.3",
+        "react-hook-form": "^7.71.1",
         "react-hot-toast": "^2.6.0",
-        "react-router-dom": "^7.1.1"
+        "react-router-dom": "^7.1.1",
+        "zod": "^4.3.5"
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
@@ -2436,6 +2439,18 @@
         }
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3469,6 +3484,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -7795,6 +7816,22 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.71.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
+      "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-hot-toast": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
@@ -10414,6 +10451,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-visually-hidden": "^1.2.4",
     "@tanstack/react-query": "^5.62.0",
@@ -22,8 +23,10 @@
     "react": "^19.2.3",
     "react-currency-input-field": "^4.0.3",
     "react-dom": "^19.2.3",
+    "react-hook-form": "^7.71.1",
     "react-hot-toast": "^2.6.0",
-    "react-router-dom": "^7.1.1"
+    "react-router-dom": "^7.1.1",
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/src/components/ui/AmountInput.tsx
+++ b/src/components/ui/AmountInput.tsx
@@ -4,6 +4,7 @@ import CurrencyInput from 'react-currency-input-field'
 interface AmountInputProps {
   value: string
   onChange: (value: string) => void
+  onBlur?: () => void
   error?: string
   label?: string
   placeholder?: string
@@ -16,6 +17,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
     {
       value,
       onChange,
+      onBlur,
       error,
       label = 'Amount',
       placeholder = '0.00',
@@ -45,6 +47,7 @@ export const AmountInput = forwardRef<HTMLInputElement, AmountInputProps>(
             onValueChange={(newValue) => {
               onChange(newValue ?? '')
             }}
+            onBlur={onBlur}
             placeholder={placeholder}
             disabled={disabled}
             autoFocus={autoFocus}

--- a/src/features/categories/CategoryFormModal.tsx
+++ b/src/features/categories/CategoryFormModal.tsx
@@ -1,7 +1,6 @@
-import { useState } from 'react'
 import { Dialog } from '@/components/ui/Dialog'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
-import { CategoryForm } from '@/features/categories/CategoryForm'
+import { CategoryForm, type CategoryFormData } from '@/features/categories/CategoryForm'
 import {
   useCreateCategory,
   useUpdateCategory,
@@ -9,7 +8,6 @@ import {
   useCategoryHasExpenses,
 } from '@/hooks/useCategories'
 import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
-import { PRESET_COLORS } from '@/constants/colors'
 import type { Category } from '@/types'
 
 interface CategoryFormModalProps {
@@ -23,9 +21,6 @@ export function CategoryFormModal({
   onClose,
   category,
 }: CategoryFormModalProps) {
-  const [name, setName] = useState(category?.name ?? '')
-  const [color, setColor] = useState<string>(category?.color ?? PRESET_COLORS[0])
-
   const createCategory = useCreateCategory()
   const updateCategory = useUpdateCategory()
   const deleteCategory = useDeleteCategory()
@@ -40,20 +35,14 @@ export function CategoryFormModal({
 
   const isEditing = !!category
 
-  const handleSave = async () => {
-    if (!name.trim()) return
-
+  const handleSave = async (data: CategoryFormData) => {
     if (isEditing && category) {
       await updateCategory.mutateAsync({
         id: category.id,
-        name: name.trim(),
-        color,
+        ...data,
       })
     } else {
-      await createCategory.mutateAsync({
-        name: name.trim(),
-        color,
-      })
+      await createCategory.mutateAsync(data)
     }
     onClose()
   }
@@ -77,14 +66,11 @@ export function CategoryFormModal({
         title={isEditing ? 'Edit Category' : 'Add Category'}
       >
         <CategoryForm
-          name={name}
-          color={color}
-          onNameChange={setName}
-          onColorChange={setColor}
+          key={category?.id ?? 'new'}
+          category={category}
           onSubmit={handleSave}
           onCancel={handleClose}
           onDelete={isEditing ? handleDelete : undefined}
-          isEditing={isEditing}
           isSubmitting={createCategory.isPending || updateCategory.isPending}
           isDeleting={deletion.isDeleting}
         />

--- a/src/features/categories/CategorySelect.tsx
+++ b/src/features/categories/CategorySelect.tsx
@@ -8,9 +8,10 @@ interface CategorySelectProps {
   value: string
   onChange: (value: string) => void
   error?: string
+  onBlur?: () => void
 }
 
-export function CategorySelect({ value, onChange, error }: CategorySelectProps) {
+export function CategorySelect({ value, onChange, error, onBlur }: CategorySelectProps) {
   const [showList, setShowList] = useState(false)
   const [editingCategory, setEditingCategory] = useState<Category | null>(null)
   const [isCreating, setIsCreating] = useState(false)
@@ -63,6 +64,7 @@ export function CategorySelect({ value, onChange, error }: CategorySelectProps) 
                 return
               }
               onChange(e.target.value)
+              onBlur?.()
               e.target.blur()
             }}
             className={`

--- a/src/features/expenses/ExpenseFormModal.tsx
+++ b/src/features/expenses/ExpenseFormModal.tsx
@@ -72,6 +72,7 @@ export function ExpenseFormModal({
         title={isEditing ? 'Edit Expense' : 'Add Expense'}
       >
         <ExpenseForm
+          key={expense?.id ?? 'new'}
           date={date}
           expense={expense}
           onSubmit={handleSubmit}


### PR DESCRIPTION
- Replace manual form state management with react-hook-form
- Add Zod schemas for type-safe validation in ExpenseForm, CategoryForm, and RangePicker
- Fix CategoryForm schema to trim before validation (whitespace-only inputs now rejected)
- Standardize useForm type parameters across all forms for consistency
- Update AmountInput to work with react-hook-form's controlled inputs