### PR TITLE
fix(pwa): remove conflicting workbox options that broke update prompt

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,10 +8,6 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: 'prompt',
-      workbox: {
-        skipWaiting: true,
-        clientsClaim: true,
-      },
       includeAssets: ['favicon.svg', 'apple-touch-icon.svg'],
       manifest: {
         name: 'Pocket Ledger',


### PR DESCRIPTION
The skipWaiting and clientsClaim options caused the service worker to activate immediately, which conflicted with registerType: 'prompt'. This made updateServiceWorker(true) ineffective since there was no waiting service worker to receive the SKIP_WAITING message.