### PR TITLE
fix(categories): clear search query on category create/edit

### DIFF
--- a/src/features/categories/CategoryFormModal.tsx
+++ b/src/features/categories/CategoryFormModal.tsx
@@ -12,7 +12,7 @@ import type { Category } from '@/types'
 
 interface CategoryFormModalProps {
   isOpen: boolean
-  onClose: (newCategoryId?: string) => void
+  onClose: (result?: { categoryId?: string; saved?: boolean }) => void
   category?: Category | null
 }
 
@@ -41,10 +41,10 @@ export function CategoryFormModal({
         id: category.id,
         ...data,
       })
-      onClose()
+      onClose({ saved: true })
     } else {
       const newCategory = await createCategory.mutateAsync(data)
-      onClose(newCategory.id)
+      onClose({ categoryId: newCategory.id, saved: true })
     }
   }
 

--- a/src/features/categories/CategoryPickerModal.tsx
+++ b/src/features/categories/CategoryPickerModal.tsx
@@ -33,13 +33,18 @@ export function CategoryPickerModal({
     onClose()
   }
 
-  const handleCloseForm = (newCategoryId?: string) => {
+  const handleCloseForm = (result?: { categoryId?: string; saved?: boolean }) => {
     setEditingCategory(null)
     setIsCreating(false)
 
+    // Clear search when a category was created or edited
+    if (result?.saved) {
+      setSearchQuery('')
+    }
+
     // Auto-select newly created category
-    if (newCategoryId) {
-      onSelect(newCategoryId)
+    if (result?.categoryId) {
+      onSelect(result.categoryId)
       onClose()
     }
   }


### PR DESCRIPTION
When a user has a search query active in the category picker modal and creates or edits a category, the newly created/edited category may not match the search filter. This clears the search query after a successful save so the category is visible. The search is preserved when cancelling.

Closes #29