### PR TITLE
feat(expenses): add autocomplete suggestions to note field

### DIFF
--- a/src/components/ui/AutocompleteInput.test.tsx
+++ b/src/components/ui/AutocompleteInput.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AutocompleteInput } from '@/components/ui/AutocompleteInput'
+
+describe('AutocompleteInput', () => {
+  it('shows suggestions when focused and has matching suggestions', () => {
+    render(
+      <AutocompleteInput
+        value="cof"
+        onChange={vi.fn()}
+        suggestions={['Coffee at Starbucks', 'Coffee beans']}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+
+    expect(screen.getByText('Coffee at Starbucks')).toBeInTheDocument()
+    expect(screen.getByText('Coffee beans')).toBeInTheDocument()
+  })
+
+  it('calls onChange with selected suggestion', () => {
+    const onChange = vi.fn()
+    render(
+      <AutocompleteInput
+        value="cof"
+        onChange={onChange}
+        suggestions={['Coffee at Starbucks']}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+
+    const suggestion = screen.getByText('Coffee at Starbucks')
+    fireEvent.click(suggestion)
+
+    expect(onChange).toHaveBeenCalledWith('Coffee at Starbucks')
+  })
+
+  it('keeps focus on input after selecting suggestion', () => {
+    render(
+      <AutocompleteInput
+        value="cof"
+        onChange={vi.fn()}
+        suggestions={['Coffee at Starbucks']}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+
+    const suggestion = screen.getByText('Coffee at Starbucks')
+    fireEvent.click(suggestion)
+
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('hides suggestions on blur (tap outside)', () => {
+    render(
+      <AutocompleteInput
+        value="cof"
+        onChange={vi.fn()}
+        suggestions={['Coffee at Starbucks']}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+
+    expect(screen.getByText('Coffee at Starbucks')).toBeInTheDocument()
+
+    fireEvent.blur(input)
+
+    expect(screen.queryByText('Coffee at Starbucks')).not.toBeInTheDocument()
+  })
+
+  it('does not show suggestions when value is empty', () => {
+    render(
+      <AutocompleteInput
+        value=""
+        onChange={vi.fn()}
+        suggestions={['Coffee at Starbucks']}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+
+    expect(screen.queryByText('Coffee at Starbucks')).not.toBeInTheDocument()
+  })
+
+  it('hides suggestions on Escape key', () => {
+    render(
+      <AutocompleteInput
+        value="cof"
+        onChange={vi.fn()}
+        suggestions={['Coffee at Starbucks']}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+
+    expect(screen.getByText('Coffee at Starbucks')).toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(screen.queryByText('Coffee at Starbucks')).not.toBeInTheDocument()
+  })
+
+  it('does not show suggestions when there are none', () => {
+    render(
+      <AutocompleteInput
+        value="xyz"
+        onChange={vi.fn()}
+        suggestions={[]}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+  })
+
+  it('displays error message when provided', () => {
+    render(
+      <AutocompleteInput
+        value=""
+        onChange={vi.fn()}
+        suggestions={[]}
+        error="Note is required"
+      />
+    )
+
+    expect(screen.getByText('Note is required')).toBeInTheDocument()
+  })
+
+  it('calls onBlur when input loses focus', () => {
+    const onBlur = vi.fn()
+    render(
+      <AutocompleteInput
+        value="test"
+        onChange={vi.fn()}
+        onBlur={onBlur}
+        suggestions={[]}
+        label="Note"
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    fireEvent.focus(input)
+    fireEvent.blur(input)
+
+    expect(onBlur).toHaveBeenCalled()
+  })
+
+  it('applies maxLength to input', () => {
+    render(
+      <AutocompleteInput
+        value=""
+        onChange={vi.fn()}
+        suggestions={[]}
+        label="Note"
+        maxLength={100}
+      />
+    )
+
+    const input = screen.getByLabelText('Note')
+    expect(input).toHaveAttribute('maxLength', '100')
+  })
+})

--- a/src/components/ui/AutocompleteInput.tsx
+++ b/src/components/ui/AutocompleteInput.tsx
@@ -1,0 +1,151 @@
+import { useState, useRef, useCallback, forwardRef } from 'react'
+
+interface AutocompleteInputProps {
+  value: string
+  onChange: (value: string) => void
+  onBlur?: () => void
+  suggestions: string[]
+  label?: string
+  placeholder?: string
+  error?: string
+  maxLength?: number
+}
+
+export const AutocompleteInput = forwardRef<HTMLInputElement, AutocompleteInputProps>(
+  (
+    {
+      value,
+      onChange,
+      onBlur,
+      suggestions,
+      label,
+      placeholder,
+      error,
+      maxLength,
+    },
+    ref
+  ) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    // Merge forwarded ref with local ref
+    const setRefs = useCallback(
+      (node: HTMLInputElement | null) => {
+        inputRef.current = node
+        if (typeof ref === 'function') {
+          ref(node)
+        } else if (ref) {
+          ref.current = node
+        }
+      },
+      [ref]
+    )
+
+    const showDropdown = isOpen && suggestions.length > 0 && value.length >= 1
+
+    const handleFocus = useCallback(() => {
+      setIsOpen(true)
+    }, [])
+
+    const handleBlur = useCallback(() => {
+      setIsOpen(false)
+      onBlur?.()
+    }, [onBlur])
+
+    const handleChange = useCallback(
+      (e: React.ChangeEvent<HTMLInputElement>) => {
+        onChange(e.target.value)
+      },
+      [onChange]
+    )
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setIsOpen(false)
+      }
+    }, [])
+
+    const handleSuggestionSelect = useCallback(
+      (suggestion: string) => {
+        onChange(suggestion)
+        setIsOpen(false)
+        // Keep focus on input
+        inputRef.current?.focus()
+      },
+      [onChange]
+    )
+
+    const inputId = label?.toLowerCase().replace(/\s+/g, '-')
+
+    return (
+      <div className="relative w-full">
+        {label && (
+          <label
+            htmlFor={inputId}
+            className="block text-sm font-medium text-[var(--color-text-primary)] mb-1"
+          >
+            {label}
+          </label>
+        )}
+        <input
+          ref={setRefs}
+          id={inputId}
+          type="text"
+          value={value}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          maxLength={maxLength}
+          className={`
+            w-full px-3 py-2 rounded-lg border
+            bg-[var(--color-bg-primary)] text-[var(--color-text-primary)]
+            placeholder:text-[var(--color-text-secondary)]
+            focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent
+            disabled:opacity-50 disabled:cursor-not-allowed
+            ${error ? 'border-red-500' : 'border-[var(--color-border)]'}
+          `}
+        />
+        {showDropdown && (
+          <div
+            className="
+              absolute z-50 w-full mt-1
+              bg-[var(--color-bg-primary)]
+              border border-[var(--color-border)]
+              rounded-lg shadow-lg
+              overflow-hidden
+            "
+            role="listbox"
+          >
+            {suggestions.map((suggestion, index) => (
+              <button
+                key={`${suggestion}-${index}`}
+                type="button"
+                role="option"
+                className="
+                  w-full px-3 py-3 min-h-[44px]
+                  text-left text-[var(--color-text-primary)]
+                  hover:bg-[var(--color-bg-secondary)]
+                  active:bg-[var(--color-bg-tertiary)]
+                  focus:outline-none focus:bg-[var(--color-bg-secondary)]
+                  border-b border-[var(--color-border)] last:border-b-0
+                "
+                onMouseDown={(e) => {
+                  // Prevent blur before selection
+                  e.preventDefault()
+                }}
+                onClick={() => handleSuggestionSelect(suggestion)}
+              >
+                {suggestion}
+              </button>
+            ))}
+          </div>
+        )}
+        {error && <p className="mt-1 text-sm text-red-500">{error}</p>}
+      </div>
+    )
+  }
+)
+
+AutocompleteInput.displayName = 'AutocompleteInput'

--- a/src/hooks/useDebounce.test.ts
+++ b/src/hooks/useDebounce.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDebounce } from '@/hooks/useDebounce'
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 200))
+    expect(result.current).toBe('initial')
+  })
+
+  it('returns debounced value after delay', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 200),
+      { initialProps: { value: 'initial' } }
+    )
+
+    expect(result.current).toBe('initial')
+
+    rerender({ value: 'updated' })
+    expect(result.current).toBe('initial')
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(result.current).toBe('updated')
+  })
+
+  it('resets timer when value changes before delay completes', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 200),
+      { initialProps: { value: 'initial' } }
+    )
+
+    rerender({ value: 'first' })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current).toBe('initial')
+
+    rerender({ value: 'second' })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current).toBe('initial')
+
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    expect(result.current).toBe('second')
+  })
+
+  it('handles rapid value changes (only last value after delay)', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 200),
+      { initialProps: { value: 'initial' } }
+    )
+
+    rerender({ value: 'a' })
+    rerender({ value: 'ab' })
+    rerender({ value: 'abc' })
+    rerender({ value: 'abcd' })
+
+    expect(result.current).toBe('initial')
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(result.current).toBe('abcd')
+  })
+})

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react'
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(timer)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/src/hooks/useNoteSuggestions.test.ts
+++ b/src/hooks/useNoteSuggestions.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { format, subMonths, subDays } from 'date-fns'
+import { useNoteSuggestions } from '@/hooks/useNoteSuggestions'
+import { db } from '@/db'
+import { createWrapper } from '@/test/setup'
+
+describe('useNoteSuggestions', () => {
+  // Fixed date for consistent testing
+  const fixedNow = new Date('2024-06-15T12:00:00.000Z')
+  const recentDate = format(subDays(fixedNow, 30), 'yyyy-MM-dd')
+  const oldDate = format(subMonths(fixedNow, 7), 'yyyy-MM-dd')
+
+  beforeEach(async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(fixedNow)
+
+    await db.categories.add({
+      id: 'cat-1',
+      name: 'Food',
+      color: '#ff0000',
+      usageCount: 0,
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns empty when no category selected', async () => {
+    const { result } = renderHook(
+      () => useNoteSuggestions({ categoryId: null, query: 'test' }),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(result.current.suggestions).toEqual([])
+  })
+
+  it('returns empty when query < 1 char', async () => {
+    const { result } = renderHook(
+      () => useNoteSuggestions({ categoryId: 'cat-1', query: '' }),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(result.current.suggestions).toEqual([])
+  })
+
+  it('returns matching suggestions with case-insensitive prefix match', async () => {
+    await db.expenses.bulkAdd([
+      {
+        id: 'exp-1',
+        date: recentDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee at Starbucks',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: 'exp-2',
+        date: recentDate,
+        amountCents: 2000,
+        categoryId: 'cat-1',
+        note: 'Lunch at restaurant',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ])
+
+    const { result } = renderHook(
+      () => useNoteSuggestions({ categoryId: 'cat-1', query: 'cof' }),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(result.current.suggestions).toContain('Coffee at Starbucks')
+    })
+    expect(result.current.suggestions).not.toContain('Lunch at restaurant')
+  })
+
+  it('de-duplicates notes', async () => {
+    await db.expenses.bulkAdd([
+      {
+        id: 'exp-1',
+        date: recentDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: 'exp-2',
+        date: recentDate,
+        amountCents: 2000,
+        categoryId: 'cat-1',
+        note: 'Coffee',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ])
+
+    const { result } = renderHook(
+      () => useNoteSuggestions({ categoryId: 'cat-1', query: 'c' }),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(result.current.suggestions).toHaveLength(1)
+    })
+    expect(result.current.suggestions).toEqual(['Coffee'])
+  })
+
+  it('limits to max 3 suggestions', async () => {
+    await db.expenses.bulkAdd([
+      {
+        id: 'exp-1',
+        date: recentDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee 1',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: 'exp-2',
+        date: recentDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee 2',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: 'exp-3',
+        date: recentDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee 3',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: 'exp-4',
+        date: recentDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee 4',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ])
+
+    const { result } = renderHook(
+      () => useNoteSuggestions({ categoryId: 'cat-1', query: 'c' }),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(result.current.suggestions).toHaveLength(3)
+    })
+  })
+
+  it('excludes notes older than 6 months', async () => {
+    await db.expenses.bulkAdd([
+      {
+        id: 'exp-recent',
+        date: recentDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee recent',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+      {
+        id: 'exp-old',
+        date: oldDate,
+        amountCents: 1000,
+        categoryId: 'cat-1',
+        note: 'Coffee old',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ])
+
+    const { result } = renderHook(
+      () => useNoteSuggestions({ categoryId: 'cat-1', query: 'c' }),
+      { wrapper: createWrapper() }
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(200)
+    })
+
+    await waitFor(() => {
+      expect(result.current.suggestions).toContain('Coffee recent')
+    })
+    expect(result.current.suggestions).not.toContain('Coffee old')
+  })
+
+  it('respects debounce delay', async () => {
+    await db.expenses.add({
+      id: 'exp-1',
+      date: recentDate,
+      amountCents: 1000,
+      categoryId: 'cat-1',
+      note: 'Coffee',
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    })
+
+    const { result, rerender } = renderHook(
+      ({ query }) => useNoteSuggestions({ categoryId: 'cat-1', query }),
+      { wrapper: createWrapper(), initialProps: { query: '' } }
+    )
+
+    rerender({ query: 'c' })
+
+    // Before debounce
+    expect(result.current.suggestions).toEqual([])
+
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+
+    // Still before debounce completes
+    expect(result.current.suggestions).toEqual([])
+
+    await act(async () => {
+      vi.advanceTimersByTime(100)
+    })
+
+    // After debounce
+    await waitFor(() => {
+      expect(result.current.suggestions).toContain('Coffee')
+    })
+  })
+})

--- a/src/hooks/useNoteSuggestions.ts
+++ b/src/hooks/useNoteSuggestions.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react'
+import { subMonths, format } from 'date-fns'
+import { useExpensesByCategory } from '@/hooks/useExpenses'
+import { useDebounce } from '@/hooks/useDebounce'
+
+interface UseNoteSuggestionsOptions {
+  categoryId: string | null
+  query: string
+  maxSuggestions?: number
+  minQueryLength?: number
+  debounceMs?: number
+}
+
+interface UseNoteSuggestionsResult {
+  suggestions: string[]
+  isLoading: boolean
+}
+
+export function useNoteSuggestions({
+  categoryId,
+  query,
+  maxSuggestions = 3,
+  minQueryLength = 1,
+  debounceMs = 200,
+}: UseNoteSuggestionsOptions): UseNoteSuggestionsResult {
+  const debouncedQuery = useDebounce(query, debounceMs)
+
+  const today = new Date()
+  const sixMonthsAgo = subMonths(today, 6)
+  const start = format(sixMonthsAgo, 'yyyy-MM-dd')
+  const end = format(today, 'yyyy-MM-dd')
+
+  const { data: expenses, isLoading } = useExpensesByCategory(
+    categoryId,
+    start,
+    end
+  )
+
+  const suggestions = useMemo(() => {
+    if (!categoryId || debouncedQuery.length < minQueryLength) {
+      return []
+    }
+
+    if (!expenses) {
+      return []
+    }
+
+    const normalizedQuery = debouncedQuery.toLowerCase()
+    const uniqueNotes = new Set<string>()
+
+    for (const expense of expenses) {
+      if (expense.note && expense.note.toLowerCase().startsWith(normalizedQuery)) {
+        uniqueNotes.add(expense.note)
+        if (uniqueNotes.size >= maxSuggestions) {
+          break
+        }
+      }
+    }
+
+    return Array.from(uniqueNotes)
+  }, [categoryId, debouncedQuery, minQueryLength, maxSuggestions, expenses])
+
+  return {
+    suggestions,
+    isLoading,
+  }
+}


### PR DESCRIPTION
Suggest previous notes from the same category when entering expense notes. Uses debounced input and queries the last 6 months of expenses.

Closes #31