### PR TITLE
feat(expenses): allow changing the date when creating or editing an expense

### DIFF
--- a/src/features/expenses/ExpenseDatePicker.test.tsx
+++ b/src/features/expenses/ExpenseDatePicker.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { screen, fireEvent } from '@testing-library/react'
+import { renderWithClient } from '@/test/setup'
+import { ExpenseDatePicker } from '@/features/expenses/ExpenseDatePicker'
+
+// The Dialog renders its children in both a mobile and a desktop container,
+// so calendar elements appear twice in jsdom — query with getAllBy* and act
+// on the first instance.
+
+describe('ExpenseDatePicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 5, 25)) // Wednesday, June 25, 2025
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('opens to the month of the selected date', () => {
+    renderWithClient(
+      <ExpenseDatePicker
+        isOpen
+        onClose={vi.fn()}
+        selectedDate="2025-06-24"
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByText('June 2025').length).toBeGreaterThan(0)
+  })
+
+  it('calls onSelect with the ISO date and closes when a day is tapped', () => {
+    const onSelect = vi.fn()
+    const onClose = vi.fn()
+
+    renderWithClient(
+      <ExpenseDatePicker
+        isOpen
+        onClose={onClose}
+        selectedDate="2025-06-24"
+        onSelect={onSelect}
+      />
+    )
+
+    fireEvent.click(screen.getAllByLabelText('June 20, 2025')[0])
+
+    expect(onSelect).toHaveBeenCalledWith('2025-06-20')
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('disables future days so they cannot be selected', () => {
+    const onSelect = vi.fn()
+
+    renderWithClient(
+      <ExpenseDatePicker
+        isOpen
+        onClose={vi.fn()}
+        selectedDate="2025-06-24"
+        onSelect={onSelect}
+      />
+    )
+
+    const futureDay = screen.getAllByLabelText('June 26, 2025')[0]
+    expect(futureDay).toBeDisabled()
+
+    fireEvent.click(futureDay)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('does not render calendar content when closed', () => {
+    renderWithClient(
+      <ExpenseDatePicker
+        isOpen={false}
+        onClose={vi.fn()}
+        selectedDate="2025-06-24"
+        onSelect={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText('June 2025')).not.toBeInTheDocument()
+  })
+})

--- a/src/features/expenses/ExpenseDatePicker.tsx
+++ b/src/features/expenses/ExpenseDatePicker.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react'
+import { format, addMonths, subMonths, isSameMonth } from 'date-fns'
+import { Dialog } from '@/components/ui/Dialog'
+import { PeriodNavigator } from '@/components/ui/PeriodNavigator'
+import { MonthGrid } from '@/features/calendar/MonthGrid'
+import { parseDateFromISO } from '@/lib/dates'
+
+// The picker only needs date selection, so it renders a clean grid with no
+// per-day spend totals (DayCell hides the amount when the total is 0).
+const EMPTY_DAY_TOTALS: Record<string, number> = {}
+
+interface ExpenseDatePickerProps {
+  isOpen: boolean
+  onClose: () => void
+  /** Currently selected date, ISO 'yyyy-MM-dd'. The picker opens to its month. */
+  selectedDate: string
+  onSelect: (date: string) => void
+}
+
+export function ExpenseDatePicker({
+  isOpen,
+  onClose,
+  selectedDate,
+  onSelect,
+}: ExpenseDatePickerProps) {
+  return (
+    <Dialog isOpen={isOpen} onClose={onClose} title="Select date">
+      <DatePickerCalendar
+        selectedDate={selectedDate}
+        onSelect={(date) => {
+          onSelect(date)
+          onClose()
+        }}
+      />
+    </Dialog>
+  )
+}
+
+interface DatePickerCalendarProps {
+  selectedDate: string
+  onSelect: (date: string) => void
+}
+
+// Rendered inside the Dialog, which Radix unmounts on close. That means this
+// component re-mounts on each open, so its visible month always re-anchors on
+// the selected date — no effect needed to reset navigation state.
+function DatePickerCalendar({ selectedDate, onSelect }: DatePickerCalendarProps) {
+  const [viewDate, setViewDate] = useState(() => parseDateFromISO(selectedDate))
+  const isCurrentMonth = isSameMonth(viewDate, new Date())
+
+  return (
+    <div className="space-y-4">
+      <PeriodNavigator
+        label={format(viewDate, 'MMMM yyyy')}
+        onPrevious={() => setViewDate((prev) => subMonths(prev, 1))}
+        onNext={() => setViewDate((prev) => addMonths(prev, 1))}
+        onToday={() => setViewDate(new Date())}
+        isCurrentPeriod={isCurrentMonth}
+        periodName="month"
+      />
+      <MonthGrid
+        year={viewDate.getFullYear()}
+        month={viewDate.getMonth() + 1}
+        dayTotals={EMPTY_DAY_TOTALS}
+        onDayClick={onSelect}
+        selectedDate={selectedDate}
+      />
+    </div>
+  )
+}

--- a/src/features/expenses/ExpensePage.tsx
+++ b/src/features/expenses/ExpensePage.tsx
@@ -1,15 +1,15 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom'
 import { useForm, Controller } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { format } from 'date-fns'
-import { ChevronDown } from 'lucide-react'
+import { ChevronDown, Calendar } from 'lucide-react'
 import { PageHeader } from '@/components/layout/PageHeader'
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog'
 import { AmountInput } from '@/components/ui/AmountInput'
 import { AutocompleteInput } from '@/components/ui/AutocompleteInput'
 import { Button } from '@/components/ui/Button'
+import { ExpenseDatePicker } from '@/features/expenses/ExpenseDatePicker'
 import {
   useExpense,
   useCreateExpense,
@@ -20,7 +20,12 @@ import { useCategories } from '@/hooks/useCategories'
 import { useNoteSuggestions } from '@/hooks/useNoteSuggestions'
 import { useDeleteConfirmation } from '@/hooks/useDeleteConfirmation'
 import { useExpenseFormContext } from '@/contexts/ExpenseFormContext'
-import { parseDateFromISO, isFutureDate, getTodayISO } from '@/lib/dates'
+import {
+  isFutureDate,
+  getTodayISO,
+  formatRelativeDate,
+  isValidISODate,
+} from '@/lib/dates'
 import { parseUsdToCents } from '@/services/money'
 import type { Expense } from '@/types'
 
@@ -52,6 +57,7 @@ export function ExpensePage() {
   const { id } = useParams<{ id: string }>()
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+  const [isDatePickerOpen, setIsDatePickerOpen] = useState(false)
 
   const { draft, setDraft, updateDraft, clearDraft } = useExpenseFormContext()
   const { data: expense, isLoading: expenseLoading } = useExpense(id ?? null)
@@ -75,9 +81,14 @@ export function ExpensePage() {
   const isSubmitting =
     createExpense.isPending || updateExpense.isPending || deletion.isDeleting
 
-  // Determine date from URL params or use today
+  // Determine date from URL params or use today. The param is untrusted
+  // (it comes from a shareable URL), so reject anything that isn't a valid,
+  // non-future ISO date before it flows into formatRelativeDate/persistence.
   const dateParam = searchParams.get('date')
-  const date = dateParam && !isFutureDate(dateParam) ? dateParam : getTodayISO()
+  const date =
+    dateParam && isValidISODate(dateParam) && !isFutureDate(dateParam)
+      ? dateParam
+      : getTodayISO()
 
   // Initialize draft when entering the page
   useEffect(() => {
@@ -164,6 +175,10 @@ export function ExpensePage() {
     updateDraft({ note: value })
   }
 
+  const handleDateSelect = (newDate: string) => {
+    updateDraft({ date: newDate })
+  }
+
   const handleCategoryClick = () => {
     // Save current form state before navigating
     const pickerPath = id ? `/expenses/${id}/category` : '/expenses/new/category'
@@ -181,6 +196,7 @@ export function ExpensePage() {
     if (isEditing && expense) {
       await updateExpense.mutateAsync({
         id: expense.id,
+        date: formDate,
         amountCents: data.amount,
         categoryId: data.categoryId,
         note: data.note,
@@ -229,7 +245,6 @@ export function ExpensePage() {
   }
 
   const formDate = draft?.date ?? date
-  const dateObj = parseDateFromISO(formDate)
 
   return (
     <>
@@ -239,10 +254,27 @@ export function ExpensePage() {
       />
       <div className="p-4">
         <form onSubmit={handleSubmit(onFormSubmit)} className="space-y-4">
-          <div className="text-sm text-[var(--color-text-secondary)]">
-            Date: {format(dateObj, 'MMMM d, yyyy')}
+          <div className="w-full">
+            <span className="block text-sm font-medium text-[var(--color-text-primary)] mb-1">
+              Date
+            </span>
+            <button
+              type="button"
+              onClick={() => setIsDatePickerOpen(true)}
+              data-testid="date-trigger"
+              className={`
+                w-full py-2 px-3 rounded-lg border text-left flex items-center gap-2
+                bg-[var(--color-bg-primary)] text-[var(--color-text-primary)]
+                focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent
+                ${errors.root?.date ? 'border-red-500' : 'border-[var(--color-border)]'}
+              `}
+            >
+              <Calendar className="w-5 h-5 text-[var(--color-text-secondary)] flex-shrink-0" />
+              <span className="flex-1 truncate">{formatRelativeDate(formDate)}</span>
+              <ChevronDown className="w-5 h-5 text-[var(--color-text-secondary)] flex-shrink-0" />
+            </button>
             {errors.root?.date && (
-              <p className="text-red-500 mt-1">{errors.root.date.message}</p>
+              <p className="mt-1 text-sm text-red-500">{errors.root.date.message}</p>
             )}
           </div>
 
@@ -343,6 +375,13 @@ export function ExpensePage() {
           </div>
         </form>
       </div>
+
+      <ExpenseDatePicker
+        isOpen={isDatePickerOpen}
+        onClose={() => setIsDatePickerOpen(false)}
+        selectedDate={formDate}
+        onSelect={handleDateSelect}
+      />
 
       <ConfirmDialog
         isOpen={deletion.isOpen}

--- a/src/lib/dates.test.ts
+++ b/src/lib/dates.test.ts
@@ -7,6 +7,8 @@ import {
   getYearRange,
   isToday,
   isFutureDate,
+  isValidISODate,
+  formatRelativeDate,
   isCurrentOrFutureMonth,
   getTodayISO,
   isCurrentPeriod,
@@ -127,6 +129,74 @@ describe('isFutureDate', () => {
   it('returns false for past dates', () => {
     expect(isFutureDate('2024-01-14')).toBe(false)
     expect(isFutureDate('2023-12-31')).toBe(false)
+  })
+})
+
+describe('isValidISODate', () => {
+  it('accepts valid canonical ISO dates', () => {
+    expect(isValidISODate('2025-06-25')).toBe(true)
+    expect(isValidISODate('2024-02-29')).toBe(true) // leap day
+  })
+
+  it('rejects unparseable strings', () => {
+    expect(isValidISODate('not-a-date')).toBe(false)
+    expect(isValidISODate('')).toBe(false)
+  })
+
+  it('rejects impossible dates', () => {
+    expect(isValidISODate('2025-02-30')).toBe(false)
+    expect(isValidISODate('2025-13-45')).toBe(false)
+    expect(isValidISODate('2023-02-29')).toBe(false) // non-leap year
+  })
+
+  it('rejects non-canonical formats', () => {
+    expect(isValidISODate('2025-2-3')).toBe(false)
+    expect(isValidISODate('2025/06/25')).toBe(false)
+  })
+})
+
+describe('formatRelativeDate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2025, 5, 25)) // Wednesday, June 25, 2025
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns "Today" for today', () => {
+    expect(formatRelativeDate('2025-06-25')).toBe('Today')
+  })
+
+  it('returns the raw string for invalid input instead of throwing', () => {
+    expect(() => formatRelativeDate('not-a-date')).not.toThrow()
+    expect(formatRelativeDate('not-a-date')).toBe('not-a-date')
+    expect(formatRelativeDate('2025-13-45')).toBe('2025-13-45')
+  })
+
+  it('returns "Yesterday" for one day ago', () => {
+    expect(formatRelativeDate('2025-06-24')).toBe('Yesterday')
+  })
+
+  it('returns the weekday name for 2-6 days ago', () => {
+    expect(formatRelativeDate('2025-06-23')).toBe('Last Monday') // 2 days ago
+    expect(formatRelativeDate('2025-06-19')).toBe('Last Thursday') // 6 days ago
+  })
+
+  it('returns "MMM d" for 7+ days ago within the same year', () => {
+    expect(formatRelativeDate('2025-06-18')).toBe('Jun 18') // 7 days ago
+    expect(formatRelativeDate('2025-01-15')).toBe('Jan 15')
+  })
+
+  it('returns "MMM d, yyyy" for a date in an earlier year', () => {
+    expect(formatRelativeDate('2024-06-03')).toBe('Jun 3, 2024')
+  })
+
+  it('prefers the weekday tier over the year tier across a year boundary', () => {
+    vi.setSystemTime(new Date(2026, 0, 2)) // Friday, January 2, 2026
+    expect(formatRelativeDate('2025-12-30')).toBe('Last Tuesday') // 3 days ago, prior year
+    expect(formatRelativeDate('2025-12-01')).toBe('Dec 1, 2025') // >6 days ago, prior year
   })
 })
 

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -9,6 +9,9 @@ import {
   endOfYear,
   addDays,
   isToday as dateFnsIsToday,
+  isYesterday,
+  differenceInCalendarDays,
+  isValid,
   isFuture,
   isSameWeek,
   isSameMonth,
@@ -78,6 +81,17 @@ export function isToday(dateStr: string): boolean {
 }
 
 /**
+ * Check if a string is a valid, canonical ISO date 'yyyy-MM-dd'.
+ * Rejects unparseable strings (e.g. 'not-a-date'), impossible dates
+ * (e.g. '2025-02-30'), and non-canonical forms that would round-trip
+ * differently (e.g. '2025-2-3').
+ */
+export function isValidISODate(str: string): boolean {
+  const date = parseDateFromISO(str)
+  return isValid(date) && formatDateToISO(date) === str
+}
+
+/**
  * Check if a date string represents a future date
  */
 export function isFutureDate(dateStr: string): boolean {
@@ -86,6 +100,32 @@ export function isFutureDate(dateStr: string): boolean {
   const today = new Date()
   today.setHours(0, 0, 0, 0)
   return isFuture(date) && date > today
+}
+
+/**
+ * Format an ISO date string into a human-readable label whose precision
+ * depends on how far the date is from today:
+ *   today          -> "Today"
+ *   1 day ago      -> "Yesterday"
+ *   2-6 days ago   -> "Last Tuesday"
+ *   same year      -> "Jun 3"
+ *   earlier year   -> "Jun 3, 2024"
+ */
+export function formatRelativeDate(dateStr: string): string {
+  const date = parseDateFromISO(dateStr)
+  // Defensive: an unparseable string would make date-fns format() throw a
+  // RangeError during render. Fall back to the raw string instead of crashing.
+  if (!isValid(date)) return dateStr
+  const now = new Date()
+
+  if (dateFnsIsToday(date)) return 'Today'
+  if (isYesterday(date)) return 'Yesterday'
+
+  const daysAgo = differenceInCalendarDays(now, date)
+  if (daysAgo >= 2 && daysAgo <= 6) return `Last ${format(date, 'EEEE')}`
+
+  if (date.getFullYear() === now.getFullYear()) return format(date, 'MMM d')
+  return format(date, 'MMM d, yyyy')
 }
 
 /**


### PR DESCRIPTION
The expense date was read-only in the form and was never saved on edit. Add an editable date field: a trigger button shows the date and opens a calendar picker (reusing the existing Dialog + month grid), and edits now persist the date. The date is shown in a readable relative format (Today / Yesterday / Last Tuesday / Jun 3 / Jun 3, 2024) via a new formatRelativeDate util.

Also validate the untrusted ?date= URL param and guard formatRelativeDate against invalid input, preventing a render-time crash on malformed dates.