### PR TITLE
chore(eslint): enable type-aware lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,4 +25,26 @@ export default tseslint.config(
       ],
     },
   },
+  {
+    // Type-aware linting for source files. Scoped to src so config files such
+    // as vite.config.ts (covered only by tsconfig.node.json) are not forced
+    // through the TypeScript project service.
+    files: ['src/**/*.{ts,tsx}'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unnecessary-type-assertion': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      // Async functions passed to JSX event attributes (onClick/onSubmit) are
+      // idiomatic React; React ignores their return value.
+      '@typescript-eslint/no-misused-promises': [
+        'error',
+        { checksVoidReturn: { attributes: false } },
+      ],
+    },
+  },
 )

--- a/src/components/ui/AmountInput.test.tsx
+++ b/src/components/ui/AmountInput.test.tsx
@@ -59,7 +59,7 @@ describe('AmountInput', () => {
       const onChange = vi.fn()
       render(<AmountInput value="1234.56" onChange={onChange} />)
 
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
 
       expect(input.value).toBe('$1,234.56')
@@ -69,21 +69,21 @@ describe('AmountInput', () => {
   describe('thousand separators', () => {
     it('displays thousand separators for large amounts', () => {
       render(<AmountInput value="1234.56" onChange={vi.fn()} />)
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$1,234.56')
     })
 
     it('displays thousand separators for amounts over 10000', () => {
       render(<AmountInput value="12345.67" onChange={vi.fn()} />)
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$12,345.67')
     })
 
     it('displays thousand separators for amounts up to max value', () => {
       render(<AmountInput value="999999.99" onChange={vi.fn()} />)
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$999,999.99')
     })
@@ -94,7 +94,7 @@ describe('AmountInput', () => {
       const onChange = vi.fn()
       render(<AmountInput value="" onChange={onChange} />)
 
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
 
       expect(onChange).toHaveBeenCalledWith('0.00')
@@ -114,7 +114,7 @@ describe('AmountInput', () => {
       const onChange = vi.fn()
       render(<AmountInput value="0.00" onChange={onChange} />)
 
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
 
       expect(input.value).toBe('$0.00')
@@ -123,14 +123,14 @@ describe('AmountInput', () => {
     it('shows empty when not focused and value is zero', () => {
       render(<AmountInput value="0.00" onChange={vi.fn()} />)
 
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       expect(input.value).toBe('')
     })
 
     it('shows formatted value when not focused and value is non-zero', () => {
       render(<AmountInput value="12.34" onChange={vi.fn()} />)
 
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       expect(input.value).toBe('$12.34')
     })
   })
@@ -217,7 +217,7 @@ describe('AmountInput', () => {
   describe('display', () => {
     it('includes dollar sign in formatted display', () => {
       render(<AmountInput value="10.00" onChange={vi.fn()} />)
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$10.00')
     })
@@ -288,21 +288,21 @@ describe('AmountInput', () => {
   describe('controlled value', () => {
     it('displays formatted value from props when focused', () => {
       render(<AmountInput value="25.00" onChange={vi.fn()} />)
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$25.00')
     })
 
     it('displays value with thousand separators from props when focused', () => {
       render(<AmountInput value="1025.00" onChange={vi.fn()} />)
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$1,025.00')
     })
 
     it('updates display when value prop changes', () => {
       const { rerender } = render(<AmountInput value="10.00" onChange={vi.fn()} />)
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$10.00')
 
@@ -326,7 +326,7 @@ describe('AmountInput', () => {
     it('hides value when blurred with zero amount', () => {
       render(<AmountInput value="0.00" onChange={vi.fn()} />)
 
-      const input = screen.getByLabelText('Amount') as HTMLInputElement
+      const input = screen.getByLabelText<HTMLInputElement>('Amount')
       fireEvent.focus(input)
       expect(input.value).toBe('$0.00')
 

--- a/src/contexts/ExpenseFormContext.tsx
+++ b/src/contexts/ExpenseFormContext.tsx
@@ -92,9 +92,9 @@ export function ExpenseFormProvider({ children }: ExpenseFormProviderProps) {
       // point can't accidentally skip the clear.
       setDraftState(null)
       if ('id' in target) {
-        navigate(`/expenses/${target.id}`)
+        void navigate(`/expenses/${target.id}`)
       } else {
-        navigate(`/expenses/new?date=${target.date}`)
+        void navigate(`/expenses/new?date=${target.date}`)
       }
     },
     [navigate]

--- a/src/features/categories/CategoryFormPage.tsx
+++ b/src/features/categories/CategoryFormPage.tsx
@@ -44,7 +44,7 @@ export function CategoryFormPage() {
     // If coming from expense flow and have a category, go directly to expense form
     if (expenseFormPath && categoryId) {
       updateDraft({ categoryId })
-      navigate(expenseFormPath, { replace: true })
+      void navigate(expenseFormPath, { replace: true })
       return
     }
 
@@ -54,9 +54,9 @@ export function CategoryFormPage() {
     }
 
     if (returnPath) {
-      navigate(returnPath)
+      void navigate(returnPath)
     } else {
-      navigate('/categories')
+      void navigate('/categories')
     }
   }
 
@@ -87,7 +87,7 @@ export function CategoryFormPage() {
   const categoryNotFound = id && !category && categories.length > 0
   useEffect(() => {
     if (categoryNotFound) {
-      navigate('/categories')
+      void navigate('/categories')
     }
   }, [categoryNotFound, navigate])
 

--- a/src/features/categories/CategoryPickerPage.tsx
+++ b/src/features/categories/CategoryPickerPage.tsx
@@ -40,7 +40,7 @@ export function CategoryPickerPage() {
 
   const handleCategoryClick = (categoryId: string) => {
     updateDraft({ categoryId })
-    navigate(returnPath)
+    void navigate(returnPath)
   }
 
   const handleCreateCategory = () => {
@@ -51,7 +51,7 @@ export function CategoryPickerPage() {
     if (searchQuery.trim()) {
       params.set('initialName', searchQuery.trim())
     }
-    navigate(`/categories/new?${params.toString()}`)
+    void navigate(`/categories/new?${params.toString()}`)
   }
 
   const handleEditCategory = (categoryId: string) => {
@@ -59,11 +59,11 @@ export function CategoryPickerPage() {
       returnPath: pickerPath,
       expenseFormPath: returnPath,
     })
-    navigate(`/categories/${categoryId}?${params.toString()}`)
+    void navigate(`/categories/${categoryId}?${params.toString()}`)
   }
 
   const handleBack = () => {
-    navigate(returnPath)
+    void navigate(returnPath)
   }
 
   return (

--- a/src/features/expenses/ExpensePage.tsx
+++ b/src/features/expenses/ExpensePage.tsx
@@ -79,7 +79,7 @@ export function ExpensePage() {
     },
     onSuccess: () => {
       clearDraft()
-      navigate('/calendar')
+      void navigate('/calendar')
     },
   })
 
@@ -164,7 +164,7 @@ export function ExpensePage() {
       expenseId: id,
     })
     const pickerPath = id ? `/expenses/${id}/category` : '/expenses/new/category'
-    navigate(`${pickerPath}?date=${formDate}`)
+    void navigate(`${pickerPath}?date=${formDate}`)
   }
 
   const onFormSubmit = async (data: ExpenseFormData) => {
@@ -191,7 +191,7 @@ export function ExpensePage() {
     }
 
     clearDraft()
-    navigate('/calendar')
+    void navigate('/calendar')
   }
 
   const handleDelete = () => {
@@ -202,7 +202,7 @@ export function ExpensePage() {
 
   const handleCancel = () => {
     clearDraft()
-    navigate('/calendar')
+    void navigate('/calendar')
   }
 
   // Show loading state when editing and expense not loaded yet

--- a/src/features/insights/CategoryExpenseList.tsx
+++ b/src/features/insights/CategoryExpenseList.tsx
@@ -28,7 +28,7 @@ export function CategoryExpenseList({
   const category = categories.find((c) => c.id === categoryId)
 
   const handleEditExpense = (expense: Expense) => {
-    navigate(`/expenses/${expense.id}`)
+    void navigate(`/expenses/${expense.id}`)
   }
 
   return (

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -32,7 +32,7 @@ export function useCreateCategory() {
   return useMutation({
     mutationFn: (input: Pick<Category, 'name' | 'color'>) => createCategory(input),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY })
+      void queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY })
       toast.success('Category created')
     },
     onError: () => {
@@ -51,7 +51,7 @@ export function useUpdateCategory() {
     }: { id: string } & Partial<Pick<Category, 'name' | 'color'>>) =>
       updateCategory(id, patch),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY })
+      void queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY })
       toast.success('Category updated')
     },
     onError: () => {
@@ -66,7 +66,7 @@ export function useDeleteCategory() {
   return useMutation({
     mutationFn: (id: string) => deleteCategory(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY })
+      void queryClient.invalidateQueries({ queryKey: CATEGORIES_KEY })
       toast.success('Category deleted')
     },
     onError: () => {

--- a/src/hooks/useExpenses.ts
+++ b/src/hooks/useExpenses.ts
@@ -66,8 +66,8 @@ export function useCreateExpense() {
   return useMutation({
     mutationFn: (input: CreateExpenseInput) => createExpense(input),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: EXPENSES_KEY })
-      queryClient.invalidateQueries({ queryKey: ['categories'] })
+      void queryClient.invalidateQueries({ queryKey: EXPENSES_KEY })
+      void queryClient.invalidateQueries({ queryKey: ['categories'] })
       toast.success('Expense added')
     },
     onError: () => {
@@ -83,8 +83,8 @@ export function useUpdateExpense() {
     mutationFn: ({ id, ...patch }: { id: string } & UpdateExpenseInput) =>
       updateExpense(id, patch),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: EXPENSES_KEY })
-      queryClient.invalidateQueries({ queryKey: ['categories'] })
+      void queryClient.invalidateQueries({ queryKey: EXPENSES_KEY })
+      void queryClient.invalidateQueries({ queryKey: ['categories'] })
       toast.success('Expense updated')
     },
     onError: () => {
@@ -99,7 +99,7 @@ export function useDeleteExpense() {
   return useMutation({
     mutationFn: (id: string) => deleteExpense(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: EXPENSES_KEY })
+      void queryClient.invalidateQueries({ queryKey: EXPENSES_KEY })
       toast.success('Expense deleted')
     },
     onError: () => {

--- a/src/hooks/usePWAUpdate.ts
+++ b/src/hooks/usePWAUpdate.ts
@@ -11,14 +11,14 @@ export function usePWAUpdate() {
       if (registration) {
         // Check for updates periodically
         setInterval(() => {
-          registration.update()
+          void registration.update()
         }, UPDATE_CHECK_INTERVAL)
       }
     },
   })
 
   const applyUpdate = () => {
-    updateServiceWorker(true)
+    void updateServiceWorker(true)
   }
 
   return {


### PR DESCRIPTION
## What

Adds a `src`-scoped type-aware ESLint block (`parserOptions.projectService`) to the existing `typescript-eslint` flat config and enables three correctness rules:

- `@typescript-eslint/no-unnecessary-type-assertion`
- `@typescript-eslint/no-floating-promises`
- `@typescript-eslint/no-misused-promises` with `checksVoidReturn: { attributes: false }`, so async JSX event handlers (idiomatic React, return value ignored) are not flagged.

## Why src-scoped

Enabling `projectService` unscoped errors on `vite.config.ts`, which is covered only by `tsconfig.node.json` (not the default `tsconfig.json`) and so isn't found by the project service. Scoping the type-aware block to `src/**/*.{ts,tsx}` avoids this; config files don't need these rules. No dependency change (TS 5.9, `typescript-eslint` already a direct dep).

## Findings fixed

- **`AmountInput.test.tsx`**: all 13 `no-unnecessary-type-assertion` hits were the same false positive: `screen.getByLabelText('Amount') as HTMLInputElement`. `getByLabelText` returns `HTMLElement`, so the cast is genuinely needed for `.value` (removing it fails `tsc`), the rule trips on the query's generic-with-default return type. Fixed by switching to the idiomatic generic form `getByLabelText<HTMLInputElement>('Amount')`, which removes the assertion without a disable.
- **25 fire-and-forget promises** prefixed with `void` (react-router `navigate`, react-query `invalidateQueries`, service-worker `update`/`updateServiceWorker`) — behavior-preserving; the results were already ignored.

## Verification

- `npm run lint` — 0 errors (3 pre-existing `react-hooks`/`react-refresh` warnings remain, identical to `main`; `eslint .` exits 0 on warnings)
- `npm run typecheck` — clean
- `npm run test:run` — 272/272 passing

Lint, typecheck, and tests all run on CI (`ci.yml`), so the rules are enforced with no workflow changes.