### PR TITLE
docs(agents): point dependency versions at package.json

### DIFF
--- a/.github/code-improver/PROMPT.md
+++ b/.github/code-improver/PROMPT.md
@@ -1,6 +1,6 @@
 # Code Improver
 
-You are an autonomous, scheduled code-improvement agent for the `diegocasmo/pocket-ledger` repository (a Vite + React 19 + TypeScript, local-first PWA backed by Dexie/IndexedDB; read `AGENTS.md`). You run once daily on GitHub Actions with no memory of prior runs and no human watching live; a PR from an earlier run may still be open and unmerged when you start.
+You are an autonomous, scheduled code-improvement agent for the `diegocasmo/pocket-ledger` repository (a Vite + React + TypeScript, local-first PWA backed by Dexie/IndexedDB; read `AGENTS.md`). You run once daily on GitHub Actions with no memory of prior runs and no human watching live; a PR from an earlier run may still be open and unmerged when you start.
 
 Each run: pick AT MOST ONE improvement theme (one qualifying category below, e.g. dead code) and drive it to closure across the in-scope code, fixing every genuinely high-certainty, behavior-preserving instance. Validate it through the full gate, then open ONE pull request (ready for review). If nothing clears the bar, do nothing and say so. A no-op is always better than a low-value or wrong PR.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,17 +41,7 @@ Five layers, presentation → storage:
 
 ## Tech Stack
 
-| Area | Stack (major.minor) |
-|---|---|
-| UI / build | React 19.2, TypeScript 5.9, Vite 8.0, Tailwind 4.3 |
-| Routing | React Router 7.18 |
-| Data | TanStack Query 5.101, Dexie 4.4 (IndexedDB) |
-| Forms | React Hook Form 7.80, Zod 4.4, `@hookform/resolvers` |
-| UI libs | Radix UI (Dialog), lucide-react, react-hot-toast, react-currency-input-field |
-| PWA | vite-plugin-pwa 1.3 (Workbox) |
-| Testing | Vitest 4.1, React Testing Library 16.3, fake-indexeddb 6.2, jsdom |
-
-Authoritative versions: `package.json`. These minors are Dependabot-bumped frequently — don't treat them as exact.
+See `package.json` for the authoritative list of dependencies and versions. Do not list dependency versions in docs; `package.json` is the single source of truth.
 
 ## Project Structure
 


### PR DESCRIPTION
`package.json` is the SSOT for packages and versions, so the Tech Stack table in AGENTS.md just drifts: it was already stale in two places (Vite 8.0 vs ^8.1.3, React Hook Form 7.80 vs ^7.81.0) despite its own "don't treat them as exact" caveat. Replaced the table with a pointer plus a rule that versions are never listed in docs. The table's non-version facts (Dexie, React Query, Router, Workbox, testing stack) already have their own sections.

Also dropped the React 19 pin from the Code Improver prompt preamble; the architectural nouns stay. Same fix as diegocasmo/findmomentum.xyz#550.
