### PR TITLE
docs(agents): kill stale component enumerations, harden doc-accuracy rule

### DIFF
--- a/.github/code-improver/PROMPT.md
+++ b/.github/code-improver/PROMPT.md
@@ -29,7 +29,7 @@ A theme is ONE of the categories below. Within it, act ONLY on instances where y
 - **Type safety**: remove an `any`, an unnecessary `as` cast, or a non-null assertion; tighten a loose type; infer a type from a Zod schema. Only where it cannot change runtime behavior and matches existing patterns.
 - **Dead code**: remove a provably-unused export, variable, import, or unreachable branch. Verify there are no references anywhere first. Remember page components carry an intentional `default` export for `React.lazy`, so a `default` export is not dead.
 - **Refactor or simplification**: an unambiguous readability or structure win that preserves behavior (for example, collapse duplicated logic into an existing helper, prefer `??` over `||` for a default per `AGENTS.md`, or simplify a needlessly convoluted expression). Never a stylistic preference, never bundled with unrelated cleanup. A refactor theme is one cohesive refactor, not a repo-wide sweep; each is bespoke.
-- **Documentation accuracy** in `README.md` or `AGENTS.md`: a command, convention, or claim that no longer matches the code.
+- **Documentation accuracy** in `README.md` or `AGENTS.md`: a command, convention, or claim that no longer matches the code. Fix per the "Keeping this file useful" section in `AGENTS.md`: delete the stale claim or convert it to a `file` + symbol pointer. Never re-sync a copied detail, paste code, or introduce a `file:line` reference into a doc.
 
 Do NOT: add features, change runtime behavior to fix a latent bug, add validation or guards that change which inputs are accepted, touch an excluded path, or make subjective wording or tone changes. If the obvious candidates are already fine, that is a no-op.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,8 +134,8 @@ The expense form (`ExpensePage.tsx`) has subtle, deliberate choices — read it 
 
 ## Components
 
-- **`src/components/ui/`** — presentational primitives only (props in, callbacks out; no data fetching or business logic): `Button`, `Input`, `Dialog` (Radix-backed — bottom-sheet on mobile, centered modal on desktop), `ConfirmDialog`, `AmountInput` (cents-based currency input), `AutocompleteInput` (debounced suggestions, ARIA listbox).
-- **`src/components/layout/`** — `AppLayout` (theme, bottom nav, provides `CalendarContext`; consumes `ExpenseFormContext`), `BottomNav` (nav + add-expense FAB), `PageHeader`.
+- **`src/components/ui/`**: presentational primitives only (props in, callbacks out; no data fetching or business logic). See the directory for the current set; the ones with non-obvious behavior are `Dialog` (Radix-backed; bottom-sheet on mobile, centered modal on desktop), `AmountInput` (cents-based currency input), and `AutocompleteInput` (suggestions rendered as an ARIA listbox; debouncing lives in `useNoteSuggestions`, not the primitive).
+- **`src/components/layout/`**: app chrome. See the directory for the current set; the load-bearing ones are `AppLayout` (theme, bottom nav; provides `CalendarContext`, consumes `ExpenseFormContext`) and `BottomNav` (nav plus add-expense FAB).
 - `forwardRef` for primitives needing ref access; one component per file. Theme via CSS variables (`var(--color-*)`, defined in `src/index.css`).
 
 ## PWA


### PR DESCRIPTION
## Summary

AGENTS.md here is already lean and points at code instead of pasting it, so this is a tightening, not a rewrite (unlike findmomentum #553).

The `## Components` list of `src/components/ui/` primitives had quietly gone stale: it enumerated six, but the directory has eight. `PeriodNavigator` and `SearchInput` were missing, both real and in use, and both have existed through three prior "sync AGENTS.md" passes. That is exactly the drift the file's own policy warns about, so I dropped the enumeration and pointed at the directory, keeping only the primitives with non-obvious behavior. The `layout/` bullet had the same implicit-complete framing (and was missing `CalendarContext`), so it got the same treatment.

One factual correction while there: `AutocompleteInput` does not debounce. The debounce lives in `useNoteSuggestions`, and the primitive just renders the suggestions it is handed.

## Scope

Also hardened the Code Improver prompt's documentation-accuracy rule the same way as the other two repos: a stale doc claim gets deleted or converted to a pointer, never re-synced or replaced with pasted code.