### PR TITLE
chore(ci): run Code Improver on Opus 5

### DIFF
--- a/.github/workflows/code-improver.yml
+++ b/.github/workflows/code-improver.yml
@@ -49,7 +49,7 @@ jobs:
             Read .github/code-improver/PROMPT.md and follow it EXACTLY.
           # --tools locks the available built-in set (no Agent/subagent or
           # background tools); --allowed-tools only auto-approves prompts.
-          claude_args: '--model claude-opus-4-8 --effort xhigh --max-turns 100 --tools "Bash,Edit,Write,Read,Grep,Glob" --allowed-tools "Bash,Edit,Write,Read,Grep,Glob"'
+          claude_args: '--model claude-opus-5 --effort xhigh --max-turns 100 --tools "Bash,Edit,Write,Read,Grep,Glob" --allowed-tools "Bash,Edit,Write,Read,Grep,Glob"'
 
       # A silently-stranded run still reports success, so require the agent to
       # have written a terminal marker. Absence means it never reached a PR or a


### PR DESCRIPTION
## Summary

Switches the `Code Improver` GitHub Actions routine from Opus 4.8 to Opus 5 (`--model claude-opus-5`, pinned so it won't drift to a future default Opus). Effort stays `xhigh`.

## Scope

Single line in `.github/workflows/code-improver.yml`. `PROMPT.md` names no model or effort level, so nothing else needed updating, and Opus 5 keeps the same effort ladder, so `xhigh` carries over as-is. Opus 5 does delegate to subagents more readily than 4.8, which the existing `--tools` availability lock (no `Agent`) and PROMPT.md's no-subagent rule already prevent.