### PR TITLE
fix(test): pin the clock in CalendarPage tests

### DIFF
--- a/src/features/calendar/CalendarPage.test.tsx
+++ b/src/features/calendar/CalendarPage.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { renderWithRouter } from '@/test/setup'
@@ -6,7 +6,11 @@ import { AppLayout } from '@/components/layout/AppLayout'
 import { ExpenseFormProvider } from '@/contexts/ExpenseFormContext'
 import { CalendarPage } from '@/features/calendar/CalendarPage'
 import { createCategory } from '@/db/categoriesRepo'
-import { format } from 'date-fns'
+
+// July 31 is a month-end the previous month doesn't have, which is the case
+// naive `setMonth(-1)` arithmetic gets wrong. Pinning it keeps that path
+// covered on every run instead of 7 days a year.
+const FIXED_NOW = new Date(2025, 6, 31, 12, 0, 0)
 
 function renderCalendarPage() {
   return renderWithRouter(
@@ -20,12 +24,22 @@ function renderCalendarPage() {
 }
 
 describe('CalendarPage', () => {
+  beforeEach(() => {
+    // shouldAdvanceTime keeps userEvent and waitFor progressing under fake timers
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(FIXED_NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   describe('rendering', () => {
     it('renders the current month', async () => {
       renderCalendarPage()
 
       await waitFor(() => {
-        expect(screen.getByText(format(new Date(), 'MMMM yyyy'))).toBeInTheDocument()
+        expect(screen.getByText('July 2025')).toBeInTheDocument()
       })
     })
 
@@ -49,11 +63,8 @@ describe('CalendarPage', () => {
       const prevButton = await screen.findByLabelText('Previous month')
       await user.click(prevButton)
 
-      const prevMonth = new Date()
-      prevMonth.setMonth(prevMonth.getMonth() - 1)
-
       await waitFor(() => {
-        expect(screen.getByText(format(prevMonth, 'MMMM yyyy'))).toBeInTheDocument()
+        expect(screen.getByText('June 2025')).toBeInTheDocument()
       })
     })
   })

--- a/src/features/calendar/CalendarPage.test.tsx
+++ b/src/features/calendar/CalendarPage.test.tsx
@@ -7,11 +7,6 @@ import { ExpenseFormProvider } from '@/contexts/ExpenseFormContext'
 import { CalendarPage } from '@/features/calendar/CalendarPage'
 import { createCategory } from '@/db/categoriesRepo'
 
-// July 31 is a month-end the previous month doesn't have, which is the case
-// naive `setMonth(-1)` arithmetic gets wrong. Pinning it keeps that path
-// covered on every run instead of 7 days a year.
-const FIXED_NOW = new Date(2025, 6, 31, 12, 0, 0)
-
 function renderCalendarPage() {
   return renderWithRouter(
     <ExpenseFormProvider>
@@ -25,9 +20,10 @@ function renderCalendarPage() {
 
 describe('CalendarPage', () => {
   beforeEach(() => {
-    // shouldAdvanceTime keeps userEvent and waitFor progressing under fake timers
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    vi.setSystemTime(FIXED_NOW)
+    vi.useFakeTimers({ toFake: ['Date'] })
+    // A 31st is load-bearing: stepping back a month must land on Jun 30, so
+    // month arithmetic that doesn't clamp gives Jul 1 and fails the assertion
+    vi.setSystemTime(new Date(2025, 6, 31, 12, 0, 0))
   })
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

Fixes the `CalendarPage > navigates to previous month` failure on [CI run 30648989319](https://github.com/diegocasmo/pocket-ledger/actions/runs/30648989319/job/91217332839?pr=294). It isn't flaky, it's date-dependent, and the day it broke happened to be today.

## Root cause

`src/features/calendar/CalendarPage.test.tsx:53` built the expected label with mutation arithmetic:

```js
const prevMonth = new Date()
prevMonth.setMonth(prevMonth.getMonth() - 1)
```

`Date#setMonth` doesn't clamp. On Jul 31 it sets the month to June but keeps day 31, and June has 30 days, so it overflows to **Jul 1**. The page (`CalendarPage.tsx:23`) uses date-fns `subMonths`, which clamps to **Jun 30**. So the test asserted `July 2026` against a DOM correctly showing `June 2026`.

Brute-forcing every day of the year, the two disagree on exactly 7 days: Mar 29-31, May 31, Jul 31, Oct 31, Dec 31. Roughly 2% of days, which is why it read as flaky. The CI job ran at `2026-07-31T16:54Z`.

## Scope

Rather than just swapping in `subMonths`, the test pins the clock to Jul 31 2025 and asserts literal labels (`July 2025`, `June 2025`). Recomputing the expectation from the real clock is what let the bug hide, and pinning a month-end keeps the overflow path exercised on every run instead of 7 days a year.

`toFake: ['Date']` pins the clock without faking the scheduler, so `userEvent`, `waitFor`, React Query and fake-indexeddb all keep real timers.

Test-only change, no production code touched.

## Evidence

- Reproduced on `main` with no changes: the test fails locally today with the same error CI reported.
- Mutation check: reverting the page to naive `setMonth` makes the new test fail (`Unable to find an element with the text: June 2025`), so it's a real regression guard rather than an assertion that merely passes.
- The pinned day-of-month is load-bearing, verified by counterfactual: with the same mutated page but the clock moved to Jul 15, all 4 tests pass and the regression goes unnoticed. That's what the surviving comment records.
- Passes under `TZ=UTC`, `Pacific/Kiritimati` (+14), `Pacific/Midway` (-11), `Asia/Kathmandu` (+5:45); full suite green twice plus `--sequence.shuffle`.
- `grep` for `setMonth|setFullYear|.setDate(` across `src/` returns no other hits. `InsightsPage.test.tsx:98` also derives from the real clock, but via the same `subMonths` production uses, so it can't hit this overflow.